### PR TITLE
fix(Sidebar): Cho phép bỏ chọn filter khoảng giá (Closes #45)

### DIFF
--- a/sneaker-frontend/src/components/layout/sidebar/Sidebar.jsx
+++ b/sneaker-frontend/src/components/layout/sidebar/Sidebar.jsx
@@ -99,10 +99,10 @@ function Sidebar({ onFilterChange }) {
                 <ul className="category-list">
                     {categories.map((category) => (
                         <li key={category.id}>
-                            <a 
-                                href="#" 
+                            <a
+                                href="#"
                                 // Nếu ID đang chọn trùng với ID của category này thì thêm class 'active' (để bạn tự CSS tô đậm lên)
-                                className={`category-link ${selectedCategory === category.id ? 'active-category' : ''}`} 
+                                className={`category-link ${selectedCategory === category.id ? 'active-category' : ''}`}
                                 onClick={(e) => handleCategoryClick(e, category.id)}
                             >
                                 {category.name}
@@ -150,19 +150,35 @@ function Sidebar({ onFilterChange }) {
                 {/* Danh sách các khoảng giá (Dùng Radio để chọn 1) */}
                 <div className="price-ranges">
                     <label className="radio-label">
-                        <input type="radio" name="price-filter" value="under-1m" className="radio-input" checked={priceRange === "under-1m"} onChange={handleRadioPriceChange} />
+                        <input type="radio" name="price-filter" value="under-1m" className="radio-input" checked={priceRange === "under-1m"} onChange={handleRadioPriceChange} onClick={(e) => {
+                            if (priceRange === e.target.value) {
+                                setPriceRange("");
+                            }
+                        }} />
                         <span className="radio-text">Dưới 1.000.000₫</span>
                     </label>
                     <label className="radio-label">
-                        <input type="radio" name="price-filter" value="1m-3m" className="radio-input" checked={priceRange === "1m-3m"} onChange={handleRadioPriceChange} />
+                        <input type="radio" name="price-filter" value="1m-3m" className="radio-input" checked={priceRange === "1m-3m"} onChange={handleRadioPriceChange} onClick={(e) => {
+                            if (priceRange === e.target.value) {
+                                setPriceRange("");
+                            }
+                        }} />
                         <span className="radio-text">1.000.000₫ - 3.000.000₫</span>
                     </label>
                     <label className="radio-label">
-                        <input type="radio" name="price-filter" value="3m-5m" className="radio-input" checked={priceRange === "3m-5m"} onChange={handleRadioPriceChange} />
+                        <input type="radio" name="price-filter" value="3m-5m" className="radio-input" checked={priceRange === "3m-5m"} onChange={handleRadioPriceChange} onClick={(e) => {
+                            if (priceRange === e.target.value) {
+                                setPriceRange("");
+                            }
+                        }} />
                         <span className="radio-text">3.000.000₫ - 5.000.000₫</span>
                     </label>
                     <label className="radio-label">
-                        <input type="radio" name="price-filter" value="over-5m" className="radio-input" checked={priceRange === "over-5m"} onChange={handleRadioPriceChange} />
+                        <input type="radio" name="price-filter" value="over-5m" className="radio-input" checked={priceRange === "over-5m"} onChange={handleRadioPriceChange} onClick={(e) => {
+                            if (priceRange === e.target.value) {
+                                setPriceRange("");
+                            }
+                        }} />
                         <span className="radio-text">Trên 5.000.000₫</span>
                     </label>
                 </div>


### PR DESCRIPTION
## Mô tả
Pull request này sửa lỗi bộ lọc khoảng giá trên trang danh sách sản phẩm không thể bỏ chọn sau khi người dùng đã chọn một radio button.

## Các thay đổi chính
- Hỗ trợ toggle radio khoảng giá
- Cho phép người dùng bấm lại để bỏ chọn filter giá
- Đồng bộ lại dữ liệu filter và product list
- Cập nhật UI filter sidebar

## Kết quả sau khi sửa
- Người dùng có thể bỏ chọn khoảng giá đã chọn
- Bộ lọc giá hoạt động linh hoạt hơn
- Danh sách sản phẩm cập nhật chính xác sau khi reset filter

## Kiểm tra
- [x] Test chọn khoảng giá
- [x] Test đổi khoảng giá
- [x] Test bỏ chọn khoảng giá
- [x] Test cập nhật danh sách sản phẩm
- [x] Test UI sidebar filter

## Issues liên quan
Closes #45 

## Ghi chú
Có thể mở rộng thêm nút "Reset filter" cho toàn bộ bộ lọc sản phẩm trong tương lai.

